### PR TITLE
1.41.27

### DIFF
--- a/Repetier/Constants.h
+++ b/Repetier/Constants.h
@@ -20,7 +20,7 @@
 #define CONSTANTS_H
 
 
-#define REPETIER_VERSION                    "RF.01.41.26"
+#define REPETIER_VERSION                    "RF.01.41.27"
 #define UI_PRINTER_COMPANY                  "Conrad Community"
 #define UI_VERSION_STRING                   "V " REPETIER_VERSION
 

--- a/Repetier/ui.cpp
+++ b/Repetier/ui.cpp
@@ -4058,7 +4058,7 @@ void UIDisplay::nextPreviousAction(int8_t next)
                 uint8_t heater = menuPos[menuLevel-1]; //0..1..2 mit zwei extrudern und bett. passt zum autotunesystem, weil UI_MENU_PID_EXT0_COUNT + UI_MENU_PID_EXT1_COUNT + UI_MENU_PID_BED_COUNT
                 if(heater < NUM_TEMPERATURE_LOOPS) {
                     int drive = tempController[heater]->pidDriveMin;
-                    INCREMENT_MIN_MAX(drive,1,0,255);
+                    INCREMENT_MIN_MAX(drive,1,1,255);
                     tempController[heater]->pidDriveMin = drive;
 #if FEATURE_AUTOMATIC_EEPROM_UPDATE
                     if(UI_MENU_PID_BED_COUNT > 0 && UI_MENU_PID_EXT0_COUNT + UI_MENU_PID_EXT1_COUNT + UI_MENU_PID_BED_COUNT - 1 == heater){ 
@@ -4083,7 +4083,7 @@ void UIDisplay::nextPreviousAction(int8_t next)
                 uint8_t heater = menuPos[menuLevel-1]; //0..1..2 mit zwei extrudern und bett. passt zum autotunesystem, weil UI_MENU_PID_EXT0_COUNT + UI_MENU_PID_EXT1_COUNT + UI_MENU_PID_BED_COUNT
                 if(heater < NUM_TEMPERATURE_LOOPS) {
                     int drive = tempController[heater]->pidDriveMax;
-                    INCREMENT_MIN_MAX(drive,1,0,255);
+                    INCREMENT_MIN_MAX(drive,1,1,255);
                     tempController[heater]->pidDriveMax = drive;
 #if FEATURE_AUTOMATIC_EEPROM_UPDATE
                     if(UI_MENU_PID_BED_COUNT > 0 && UI_MENU_PID_EXT0_COUNT + UI_MENU_PID_EXT1_COUNT + UI_MENU_PID_BED_COUNT - 1 == heater){ 
@@ -4108,7 +4108,7 @@ void UIDisplay::nextPreviousAction(int8_t next)
                 uint8_t heater = menuPos[menuLevel-1]; //0..1..2 mit zwei extrudern und bett. passt zum autotunesystem, weil UI_MENU_PID_EXT0_COUNT + UI_MENU_PID_EXT1_COUNT + UI_MENU_PID_BED_COUNT
                 if(heater < NUM_TEMPERATURE_LOOPS) {
                     int drive = tempController[heater]->pidMax;
-                    INCREMENT_MIN_MAX(drive,1,0,255);
+                    INCREMENT_MIN_MAX(drive,1,1,255);
                     tempController[heater]->pidMax = drive;
 #if FEATURE_AUTOMATIC_EEPROM_UPDATE
                     if(UI_MENU_PID_BED_COUNT > 0 && UI_MENU_PID_EXT0_COUNT + UI_MENU_PID_EXT1_COUNT + UI_MENU_PID_BED_COUNT - 1 == heater){ 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,12 @@
 TODO: Testing, testing ..
 TODO: Zaldo said that he experienced a hard reset while starting some Z-Calibration. (Awaiting further information about this bug)
 
+V RF.01.41.27.Mod (2018-06-15)
+- additional automatic checks for zeroes within extruder eeprom
+- autocheck that eeprom value extruder start speed is not bigger than extruder max speed
+- prevent the menu to switch some settings to 0
+- added "if FEATURE_AUTOMATIC_EEPROM_UPDATE" on some more locations
+
 V RF.01.41.26.Mod (2018-06-07)
 - not yet available temp measurements have been blocking the printer to show which sensor is defect after a restart.
 - some refactoring and cleanup of code


### PR DESCRIPTION
if zeroes are loaded from eeprom some extruder behavour is quite nasty. 0 acceleration means full speed and so on. this should prevent users (like me ^^) from using bogus configurations.